### PR TITLE
loss,logits assignment update

### DIFF
--- a/detector/train.py
+++ b/detector/train.py
@@ -105,7 +105,8 @@ def train(model: nn.Module, optimizer, device: str, loader: DataLoader, desc='Tr
             batch_size = texts.shape[0]
 
             optimizer.zero_grad()
-            loss, logits = model(texts, attention_mask=masks, labels=labels)
+            model_out = model(texts, attention_mask=masks, labels=labels)
+            loss, logits = model_out.loss, model_out.logits
             loss.backward()
             optimizer.step()
 
@@ -143,7 +144,8 @@ def validate(model: nn.Module, device: str, loader: DataLoader, votes=1, desc='V
                 texts, masks, labels = texts.to(device), masks.to(device), labels.to(device)
                 batch_size = texts.shape[0]
 
-                loss, logits = model(texts, attention_mask=masks, labels=labels)
+                model_out = model(texts, attention_mask=masks, labels=labels)
+                loss, logits = model_out.loss, model_out.logits
                 losses.append(loss)
                 logit_votes.append(logits)
 


### PR DESCRIPTION
There is a assignment error in the train.py script where in the loss and logits are considered to be 'str' type after the assignment and hence have to be updated.

Line: 108 and 146

```
loss, logits = model(texts, attention_mask=masks, labels=labels)
```
Here the loss variable is assigned as a 'str' type hence the following loss.backward() would fail stating that a 'str' type doesn't have a backward method.

In the updated code in the current PR the loss and logits are re-assigned.


**NOTE:** Related to Issue #53 